### PR TITLE
fix warning: ignore last part for rewriting when uneven count

### DIFF
--- a/ezzoom.php
+++ b/ezzoom.php
@@ -125,7 +125,7 @@ class Ezapps_Zoom_Handler
 
 			$_SERVER["REQUEST_URI"] = $test_for_rewrites[0];
 			$args = explode("/", $test_for_rewrites[1]);
-			for ($i = 0; $i < count($args); $i=$i+2)
+			for ($i = 0; $i < count($args)-1; $i=$i+2)
 				$_GET[$args[$i]] = $args[$i+1]; 
 		}
 


### PR DESCRIPTION
ezzoom was generating many warnings like the following

[Fri Dec 14 09:59:12 2012] [warn] [client 66.249.76.102] mod_fcgid: stderr: PHP Notice:  Undefined offset: 13 in /var/www/magento/htdocs/ezzoom.php on line 138

that happens because ezzoom adds '/ZOOM_INDEX' to the uri before splitting.

the fix will just ignore the last component. in my (limited) testing, it has always been 'ZOOM_INDEX'.
