### PR TITLE
file_get_contents() call on directory

### DIFF
--- a/ezzoom.php
+++ b/ezzoom.php
@@ -214,7 +214,7 @@ class Ezapps_Zoom_Handler
 
 			if ($gzip && file_exists($attempt . ".gz")) 
         			$page = file_get_contents($attempt . ".gz");
-			else if (file_exists($attempt))
+			else if (file_exists($attempt) && !is_dir($attempt))
         			$page = file_get_contents($attempt);
 
 			if ($page != false)


### PR DESCRIPTION
We ran into an issue with the module that would cause an almost blank page containing gibberish like 'ÿÿÿà'. The is_dir() check fixes this problem.
